### PR TITLE
SS-3189: Update backend libraries documentation

### DIFF
--- a/source/architecture/backend-libraries/index.html.md.erb
+++ b/source/architecture/backend-libraries/index.html.md.erb
@@ -2,7 +2,7 @@
 title: BackendLibraries
 weight: 8
 parent: /architecture
-last_reviewed_on: 2023-06-01
+last_reviewed_on: 2026-04-07
 review_in: 3 months
 ---
 
@@ -11,18 +11,24 @@ review_in: 3 months
 
 This document describes the libraries used in the backend applications of Monitor Space Hazards (MSH).
 
-### Libraries used
-The backend uses Python 3.9 as a programming language.
+### Package management
+The backend uses [uv](https://docs.astral.sh/uv/) as its package manager. Dependencies are defined in `pyproject.toml` and locked via `uv.lock`.
 
-The full list of libraries can be found in the `requirements.txt` file. To install all the libraries run `pip -r requirements.txt`.
+To install all dependencies run `uv sync`. To add a new dependency run `uv add <package>`.
+
+### Libraries used
+The backend uses Python 3.10 as a programming language.
 
 The list of the important libraries is as follows:
 
- * FastAPI - the most important part of the application. FastAPI is the web framework for building APIs or websites. It's a fast, asynchronous and standard based framework. It uses automatic documentation creation using OpenAPI standard.
+ * FastAPI - the web framework for building APIs. It's a fast, asynchronous and standards-based framework with automatic OpenAPI documentation.
  * Alembic - for maintaining database migrations
- * SQLAlchemy Core - as an ORM solution for Postgres database
+ * SQLAlchemy Core - as a query builder for PostgreSQL database
+ * Databases - async database connection library (backed by asyncpg)
+ * Pydantic - for data validation and serialization
  * Loguru - the logging solution
- * Databases - for connecting with database
- * Pydantic - for creating and validating database models
+ * Sentry SDK - for error tracking and performance monitoring
+ * boto3 - AWS SDK for S3 storage and other AWS services
+ * auth0-python - for Auth0 authentication integration
 
 <%= partial 'partials/links' %>


### PR DESCRIPTION
## Summary
- Updated Python version from 3.9 to 3.10
- Replaced `requirements.txt` / `pip` references with `uv` and `pyproject.toml`
- Added package management section
- Updated library descriptions and added Sentry SDK, boto3, auth0-python